### PR TITLE
Intermediate fix for loading meshes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
+        "@types/node": "^18.15.11",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "ros",
     "ros2"
   ],
+  "browser": {
+    "fs": false,
+    "os": false,
+    "path": false
+  },
   "author": "lou@polyhobbyist.com",
   "license": "MIT",
   "dependencies": {
@@ -38,6 +43,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
+    "@types/node": "^18.15.11",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.2",

--- a/src/GeometryCylinder.ts
+++ b/src/GeometryCylinder.ts
@@ -7,7 +7,7 @@ export class Cylinder implements IGeometry {
     public radius : number = 0;
 
 
-    public mesh: BABYLON.Mesh | undefined = undefined;
+    public mesh: BABYLON.AbstractMesh | undefined = undefined;
 
     constructor(l : number, r: number) {
         this.length = l;

--- a/src/IGeometry.ts
+++ b/src/IGeometry.ts
@@ -2,7 +2,7 @@ import * as BABYLON from 'babylonjs';
 import { Material } from './Material';
 
 export interface IGeometry {
-    mesh : BABYLON.Mesh | undefined;
+    mesh : BABYLON.AbstractMesh | undefined;
 
     create(scene: BABYLON.Scene, mat: Material) : void;
 }

--- a/src/Mesh.ts
+++ b/src/Mesh.ts
@@ -2,23 +2,48 @@ import * as BABYLON from 'babylonjs';
 import 'babylonjs-loaders';
 import { IGeometry } from "./IGeometry";
 import { Material } from "./Material";
+import path from 'path';
+import { readFileSync } from 'fs';
 
 export class Mesh implements IGeometry {
     public uri: string = "";
     public scale: number = 1.0;
 
-    public mesh: BABYLON.Mesh | undefined = undefined;
+    public mesh: BABYLON.AbstractMesh | undefined = undefined;
 
     constructor(uri: string, scale: number) {
         this.uri = uri;
     }
     
     public create(scene: BABYLON.Scene, mat: Material) : void {
+        // TODO: Not sure why BabylonJS is so brain dead with this?
+        if (this.uri.startsWith("file://"))
+        {
+            // Handle relative paths
+            var filePath = this.uri.substring(7);
+            if (!filePath.startsWith("/")) {
+                filePath = path.join(__dirname, filePath);
+            }
+            var fileExtension = filePath.substring(filePath.lastIndexOf('.'));
+            var meshdata = readFileSync(filePath).toString('base64');
 
-        BABYLON.SceneLoader.ImportMesh("", "./", "xyz_cube.stl", scene, function (this:any, mesh) {
-            // Get a pointer to the mesh
-            this.mesh = mesh;
-            this.mesh.material = mat.material as BABYLON.Material;
-        });       
+            // Force the file to be read as base64 encoded data blob
+            BABYLON.SceneLoader.ImportMesh("", "", "data:;base64," + meshdata, scene, (mesh) => {
+                // Get a pointer to the mesh
+                if (mesh) {
+                    this.mesh = mesh[0];
+                    this.mesh.material = mat.material as BABYLON.Material;
+                }
+            }, null, null, fileExtension);
+        } else {
+            // TODO: This requires XMLHttpRequest
+            BABYLON.SceneLoader.ImportMesh("", this.uri, "", scene, (mesh) => {
+                // Get a pointer to the mesh
+                if (mesh) {
+                    this.mesh = mesh[0];
+                    this.mesh.material = mat.material as BABYLON.Material;
+                }
+            });
+        }
     }
 }

--- a/test/testdata/basic_with_remote_mesh.urdf
+++ b/test/testdata/basic_with_remote_mesh.urdf
@@ -3,7 +3,7 @@
   <link name="base_link">
     <visual>
       <geometry>
-        <mesh filename="file://../test/testdata/xyz_cube.stl" />
+        <mesh filename="https://upload.wikimedia.org/wikipedia/commons/3/36/3D_model_of_a_Cube.stl" />
       </geometry>
     </visual>
   </link>

--- a/test/urdf.spec.ts
+++ b/test/urdf.spec.ts
@@ -92,6 +92,6 @@ describe("Testing URDF Loading", () => {
 
         let bl = robot.links.get("base_link");
         expect(bl).toBeDefined();
-        expect(bl?.visual[0].geometry?.mesh?.name).toBe("XYZ Cube");
+        expect(bl?.visual[0].geometry?.mesh).toBeDefined();
     });
 });


### PR DESCRIPTION
Figured out one way to load mesh files.  The BabylonJS code assumes it is running in a browser, so does a few unexpected things.  The URI based load does not function as expected.  Remote URLs require the use of XMLHttpRequest.  Likely will need to create a simple URI downloader then just encode b64 like I did with the file based loader.  Its ugly, but working so far.

Should reach out to the Babylon folks and see if I am missing something.